### PR TITLE
Insert Making Plans Project to rewrites config (#3)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -8,6 +8,10 @@
     ],
     "appAssociation": "AUTO",
     "rewrites": [
+      {"source": "/mpp/*", "destination": "/makingPlans/index.html" },
+      {"source": "/mpp", "destination": "/makingPlans/index.html" },
+      {"source": "/makingplans", "destination": "/makingPlans/index.html" },
+      {"source": "/makingplans/*", "destination": "/makingPlans/index.html" },
       {"source": "/privacidade/*", "destination": "/privacy/index.html" },
       { "source": "/privacy/*", "destination": "/privacy/index.html" }, 
       { "source": "/tos", "destination": "/privacy/tos/index.html" },


### PR DESCRIPTION
Foi necessário inserir novos caminhos de redirecionamento para que fosse possível acessa a página principal do Making Plans apenas escrevendo “/makingplans”, pois o nome da pasta esta com o P maiúsculo.
![image](https://user-images.githubusercontent.com/64799699/179872076-f4d617de-d100-434c-8f2a-7443decb4ebb.png)